### PR TITLE
Fixed library header file including line in the getting started page

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ else()
   cmake_policy(VERSION 3.18)
 endif()
 
-project( SparseBase_project VERSION 0.1.5 )
+project( SparseBase_project VERSION 0.2.1 )
 option(RUN_TESTS "Enable running tests" OFF)
 option(_HEADER_ONLY "Use the library as a header only library?" OFF)
 option(CUDA "Enable CUDA" OFF)

--- a/docs/pages/getting_started.md
+++ b/docs/pages/getting_started.md
@@ -154,7 +154,7 @@ make format
 SparseBase can be included using the ``sparsebase.h`` header file.
 
 ```cpp
-#include "sparsebase/sparsebase.h"
+#include "sparsebase.h"
 ```
 
 If desired users can include individual namespaces using their respective headers. 


### PR DESCRIPTION
When users want to include a single header file only (`sparsebase.h`), the path to that file is not inside a `sparsebase` folder. In other words, they need to use the following line to include the library:
```c++
#include "sparsebase.h"
```
Not
```c++
#include "sparsebase/sparsebase.h"
```

Changes:
- Changed the getting started page in the Usage section to reflect this.
- Incremented library version.